### PR TITLE
update node version for web-ssr.yaml

### DIFF
--- a/.github/workflows/web-ssr.yaml
+++ b/.github/workflows/web-ssr.yaml
@@ -42,6 +42,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
       - name: Use Node.js
         uses: actions/setup-node@v4.0.2
         with:
@@ -58,17 +63,17 @@ jobs:
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}
 
       - name: 'Install deps'
-        run: yarn install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: yarn build
+        run: pnpm build
         env:
           NODE_ENV: "production"
           CI: false
 
       - name: '[WEB SSR] Compress Artifacts'
         run: |
-          tar -czf public.tar.gz ${{ github.workspace }}/public ${{ github.workspace }}/.next/standalone ${{ github.workspace }}/.next/static ${{ github.workspace }}/next.config.js ${{ github.workspace }}/yarn.lock
+          tar -czf public.tar.gz ${{ github.workspace }}/public ${{ github.workspace }}/.next/standalone ${{ github.workspace }}/.next/static
     
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/web-ssr.yaml
+++ b/.github/workflows/web-ssr.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4.0.2
         with:
-          node-version: '20.14.0'
+          node-version: '18.20.3'
       - name: Login to NPM 
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
       - name: Check if login is successfull 

--- a/.github/workflows/web-ssr.yaml
+++ b/.github/workflows/web-ssr.yaml
@@ -68,7 +68,7 @@ jobs:
 
       - name: '[WEB SSR] Compress Artifacts'
         run: |
-          tar -czf public.tar.gz ${{ github.workspace }}/public ${{ github.workspace }}/.next/standalone ${{ github.workspace }}/.next/static
+          tar -czf public.tar.gz ${{ github.workspace }}/public ${{ github.workspace }}/.next/standalone ${{ github.workspace }}/.next/static ${{ github.workspace }}/next.config.js ${{ github.workspace }}/yarn.lock
     
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/web-ssr.yaml
+++ b/.github/workflows/web-ssr.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4.0.2
         with:
-          node-version: '18.12.1'
+          node-version: '20.14.0'
       - name: Login to NPM 
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
       - name: Check if login is successfull 


### PR DESCRIPTION
For our workflow, it was required to have Sharp installed. However, the previous version of Node was not suitable with the minimum Node version.
https://nextjs.org/docs/messages/sharp-missing-in-production

My initial idea was to use Node 20 but `sharp` didn't work properly. (Note: I will try node20 again to ensure consistency between projects after testing this version in production.) 

I found some workarounds, but they caused additional issues. It seemed that yarn v1 also didn't help to solve the problems.

I wanted to give `pnpm` a shot after reading https://github.com/vercel/next.js/discussions/35296#discussioncomment-8626288. Not only did it work perfectly, but it also reduced the node_modules size in k8s from 16.0K to 74B (due to a global cache). 
