### PR TITLE
For now fix the Ubuntu version to 22.04 to prevent ImageMagick problems

### DIFF
--- a/.github/workflows/rails-tests-linters.yaml
+++ b/.github/workflows/rails-tests-linters.yaml
@@ -32,7 +32,7 @@ env:
 jobs:
   Tests:
     # You must use a Linux environment when using service containers or container jobs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       RAILS_ENV: test
       TEST_DATABASE_URL: "postgres:///${{inputs.test_database_name || github.event.repository.name}}"
@@ -89,7 +89,7 @@ jobs:
         id: test_job_result
         run: echo "test_job_result=${{job.status}}" >> $GITHUB_OUTPUT
   Linters:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       linters_job_result: ${{ steps.linters_job_result.outputs.linters_job_result }}
     steps:


### PR DESCRIPTION
https://freeletics.slack.com/archives/C03HBC683/p1728480480003139

Fixing the Ubuntu version to https://github.com/actions/runner-images/blob/ubuntu22/20240922.1/images/ubuntu/Ubuntu2204-Readme.md which comes with `ImageMagick` pre-installed and therefore there the CI flow doesn't have any issue.

<img width="300" alt="Screenshot 2024-10-09 at 15 56 57" src="https://github.com/user-attachments/assets/06c1dcdf-49cc-4be8-9dc6-30c631faefcc">

----

The [latest Ubuntu](https://github.com/actions/runner-images/blob/ubuntu24/20240922.1/images/ubuntu/Ubuntu2404-Readme.md) at the time of writing doesn't include `ImageMagick` and therefore the CI flow fails when we try to use `MiniMagick` in Rails (which expects `ImageMagick` to be installed)

<img width="300" alt="Screenshot 2024-10-09 at 15 56 46" src="https://github.com/user-attachments/assets/2591e0d1-8c84-4794-aea3-81c6a83b7269">

----

 ℹ️ We will create a ticket for a follow up. 