### PR TITLE
install ImageMagick

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,5 +18,8 @@
   ignoreDeps: [
   ],
   packageRules: [
+    "description": "Auto-merge minor and patch dependency updates.",
+    "matchUpdateTypes": ["minor", "patch"],
+    "automerge": true
   ]
 }

--- a/.github/workflows/rails-tests-linters.yaml
+++ b/.github/workflows/rails-tests-linters.yaml
@@ -53,6 +53,8 @@ jobs:
     outputs:
       test_job_result: ${{ steps.test_job_result.outputs.test_job_result }}
     steps:
+      - name: Install ImageMagick
+        run: sudo apt install imagemagick
       - name: Skip Duplicate Actions
         uses: fkirc/skip-duplicate-actions@v5.3.1
         with:


### PR DESCRIPTION
`ImageMagick` is used in some BE services for image processing
Installing it manually in the CI since it is not included in The [latest Ubuntu](https://github.com/actions/runner-images/blob/ubuntu24/20240922.1/images/ubuntu/Ubuntu2404-Readme.md) any more 

Check [this](https://github.com/freeletics/actions/pull/66) PR for more info 