### PR TITLE
Webview: Remove pnpm version from the workflow file

### DIFF
--- a/.github/workflows/web-ssr.yaml
+++ b/.github/workflows/web-ssr.yaml
@@ -53,8 +53,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Use Node.js
         uses: actions/setup-node@v4.2.0


### PR DESCRIPTION
This version attribute is redundant and conflicts with the new version; we already defined it in the local package.json file. 

https://github.com/freeletics/web-service-webview-ssr/pull/227/files