### PR TITLE
PE-44610: Update Build Script to include `--mode` option

### DIFF
--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -74,7 +74,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm build
+        run: pnpm build --mode $APP_ENV
         env:
           NODE_ENV: "production"
           CI: false
@@ -85,7 +85,7 @@ jobs:
         if: github.event.repository.name == 'web-service-main'
         run: |
           tar -czf public.tar.gz dist
-          
+
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
towards https://freeletics.atlassian.net/browse/PE-44610.

with `vite` builds are slightly different than before.
the information about the environment is passed via `mode`, which is why the command needs to be updated.

to be as minimally invasive as possible, the already existing and used `APP_ENV` variable is being used.

related to: https://github.com/freeletics/web-service-main/pull/3066.
related to: https://github.com/freeletics/web-service-main/pull/3081