### PR TITLE
Fail Deployment Reminder workflow on Slack webhook errors

### DIFF
--- a/.github/workflows/deployment_reminder.yaml
+++ b/.github/workflows/deployment_reminder.yaml
@@ -42,6 +42,7 @@ jobs:
       if: ${{ steps.check_diff.outputs.send_deployment_reminder == 'true' }}
       uses: slackapi/slack-github-action@v2
       with:
+        errors: true
         webhook: ${{secrets.DEPLOYMENT_REMINDER_SLACK_WEBHOOK}}
         webhook-type: incoming-webhook
         payload: |


### PR DESCRIPTION
## Summary
- The `DEPLOYMENT_REMINDER_SLACK_WEBHOOK` secret went stale for about a month (last successful message: 2026-05-26), but every affected run of `deployment_reminder.yaml` still showed green in the Actions UI.
- Cause: `slackapi/slack-github-action@v2` swallows webhook POST failures unless its `errors` input is set to `true` — the default (`false`) makes the step exit 0 even when the webhook is invalid/revoked.
- This adds `errors: true` to the Notify Slack step so a broken webhook fails the job loudly instead of silently, going forward.

Context: found via `core-user-rails`, where the secret has since been rotated. This change is to prevent the same silent failure from recurring undetected.

## Test plan
- [x] Confirmed via the action's source (`src/send.js`) that `errors: true` routes failures through `core.setFailed`
- [x] Next scheduled run of `deployment_reminder.yaml` in a consumer repo should either post to Slack successfully or fail the job (not silently succeed) if the webhook breaks again