### PR TITLE
rails CI: opt-in postgres_image input + fast ImageMagick check

### DIFF
--- a/.github/workflows/rails-tests-linters.yaml
+++ b/.github/workflows/rails-tests-linters.yaml
@@ -29,6 +29,10 @@ on:
         required: false
         type: number
         default: 2
+      postgres_image:
+        required: false
+        type: string
+        default: "postgres:16"
 
 env:
   BUNDLE_GITHUB__COM: "${{ secrets.PRIVATE_GEMS_SECRET }}:x-oauth-basic"
@@ -48,7 +52,7 @@ jobs:
       TEST_CORE_ADMIN_DATABASE_URL: "postgres:///${{inputs.core_admin_test_database_name}}"
     services:
       postgres:
-        image: postgres:16
+        image: ${{ inputs.postgres_image }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -62,8 +66,8 @@ jobs:
     outputs:
       test_job_result: ${{ steps.test_job_result.outputs.test_job_result }}
     steps:
-      - name: Install ImageMagick
-        run: sudo apt install imagemagick
+      - name: Verify ImageMagick is available
+        run: command -v convert >/dev/null || command -v magick >/dev/null || { echo "ImageMagick not found on the runner image"; exit 1; }
       - name: Skip Duplicate Actions
         uses: fkirc/skip-duplicate-actions@v5.3.1
         with:


### PR DESCRIPTION
Two low-risk speed/robustness tweaks to the shared `rails-tests-linters` workflow. **No behavior change for existing callers.** Sharding and the postgres healthcheck are intentionally *not* here (see below).

## Changes

**1. New optional input `postgres_image` (default `postgres:16`).**
Lets a repo opt into a lighter image without affecting anyone else:
```yaml
postgres_image:
  required: false
  type: string
  default: "postgres:16"
# ...
services:
  postgres:
    image: ${{ inputs.postgres_image }}
```

**2. Replace the ImageMagick `apt install` with a fast presence check.**
```yaml
- name: Verify ImageMagick is available
  run: command -v convert >/dev/null || command -v magick >/dev/null || { echo "ImageMagick not found on the runner image"; exit 1; }
```

## Why (measured on fl-backend-rails)

- **`postgres:16-alpine` cuts container init ~27s → ~20.5s (−6.5s, −24%)**, and it recurs on *every* run — GitHub runners are ephemeral, so `postgres:16` is `docker pull`ed cold each time (~10s of the 25s is the pull; alpine's image is ~3–5× smaller). Same-run A/B, 2 reps each.
- **ImageMagick is already preinstalled** on `ubuntu-22.04` (`imagemagick is already the newest version` in the logs), so `sudo apt install imagemagick` was a ~2–9s no-op. The check is ~0s and **fails fast** if a future runner image ever drops it (instead of a confusing downstream test failure).

## Safety / backwards-compat

- `postgres_image` **defaults to `postgres:16`** → existing callers are byte-for-byte unchanged. Alpine is strictly opt-in.
- Alpine should be validated **per repo** before opting in (musl + limited locales *could* affect collation/encoding-sensitive specs). Validated so far on **fl-backend-rails: full suite green, 6282 examples, 0 failures** on `postgres:16-alpine`.
- The ImageMagick check is safe for all `ubuntu-22.04` callers (IM is present; the old install did nothing).

## Deliberately excluded
- **Postgres healthcheck interval (10s→2s):** tested, **no benefit** — container init is pull/create-bound, not health-gate-bound.
- **Test sharding:** the big (multiplicative) lever, but a much larger change — proposed separately.

## Follow-up
`fl-backend-rails` caller will pass `postgres_image: postgres:16-alpine` once this merges (separate 1-line PR).