### PR TITLE
Add actionlint CI + remove dead workflow outputs

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,24 @@
+name: Lint workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Static check of every workflow/action YAML: syntax, expression errors,
+      # unknown inputs (catches Renovate major bumps that rename/remove a `with:` key),
+      # and shellcheck over `run:` blocks. Does not execute the reusable workflows.
+      - uses: docker://rhysd/actionlint:1.7.7
+        with:
+          # shellcheck disabled: the only findings are info-level $GITHUB_OUTPUT
+          # quoting noise, unrelated to catching dependency-bump breakage.
+          args: -shellcheck= -color

--- a/.github/workflows/gha-create-tag.yaml
+++ b/.github/workflows/gha-create-tag.yaml
@@ -6,7 +6,6 @@ on:
       deploy:
         required: true
         type: string
-        default: 'true'
 
 permissions:
   id-token: write

--- a/.github/workflows/web-astro.yaml
+++ b/.github/workflows/web-astro.yaml
@@ -88,8 +88,6 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.WEB_JOB_TIMEOUT || vars.DEFAULT_JOB_TIMEOUT) }}
     env:
       APP_ENV: "${{ contains(github.ref, 'refs/tags/') && 'production' || inputs.APP_ENV }}"
-    outputs:
-      IMAGE_TAG: ${{ steps.IMAGE_TAG.outputs.IMAGE_TAG }}
     name: Build app
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/web-blog.yaml
+++ b/.github/workflows/web-blog.yaml
@@ -31,8 +31,6 @@ jobs:
   build:
     env:
       APP_ENV: "${{ contains(github.ref, 'refs/tags/') && 'production' || inputs.APP_ENV }}"
-    outputs:
-      IMAGE_TAG: ${{ steps.IMAGE_TAG.outputs.IMAGE_TAG }}
     name: Build app
     timeout-minutes: ${{ fromJSON(vars.WEB_JOB_TIMEOUT || vars.DEFAULT_JOB_TIMEOUT) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/web-ssr.yaml
+++ b/.github/workflows/web-ssr.yaml
@@ -42,8 +42,6 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.WEB_JOB_TIMEOUT || vars.DEFAULT_JOB_TIMEOUT) }}
     env:
       APP_ENV: "${{ contains(github.ref, 'refs/tags/') && 'production' || inputs.APP_ENV }}"
-    outputs:
-      IMAGE_TAG: ${{ steps.IMAGE_TAG.outputs.IMAGE_TAG }}
     name: Build app
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -32,8 +32,6 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.WEB_JOB_TIMEOUT || vars.DEFAULT_JOB_TIMEOUT) }}
     env:
       APP_ENV: "${{ contains(github.ref, 'refs/tags/') && 'production' || inputs.APP_ENV }}"
-    outputs:
-      IMAGE_TAG: ${{ steps.IMAGE_TAG.outputs.IMAGE_TAG }}
     name: Build app
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why

Every workflow in this repo is a reusable (\`workflow_call\`) workflow consumed by other repos across the org (web-service-main, web-blog, freeletics-web-astro, web-service-webview-ssr, …). Today PRs here have **no CI** — nothing validates a change before it lands, and a broken bump breaks every consumer's pipeline at once. The pile of open Renovate PRs sits unreviewed partly because there's no signal to trust.

## What

- **Add `actionlint.yaml`** — runs on `pull_request` over `.github/workflows/**` and `.github/actions/**`. Statically checks YAML syntax, `${{ }}` expressions, and action inputs. This catches the common Renovate failure mode: a major bump that renames or removes a `with:` key.
- **shellcheck disabled** (`-shellcheck=`). The only shellcheck findings were info-level `$GITHUB_OUTPUT` quoting noise, unrelated to dependency-bump breakage. Keeping it on would ship red for irrelevant reasons and train reviewers to ignore the check. Can be flipped on in a follow-up once the shell is quoted.

## Dead code removed (so the baseline is green with no ignore-list)

actionlint surfaced these pre-existing issues — all confirmed dead, safe to delete:

- **`web` / `web-blog` / `web-ssr` / `web-astro`**: the `IMAGE_TAG` job output referenced `steps.IMAGE_TAG.outputs.IMAGE_TAG`, but no step with `id: IMAGE_TAG` exists in any of them — the output was always empty. It is **not** exposed via `workflow_call.outputs`, and grepping all consumer repos found **zero** references to it. Pure vestigial output.
- **`gha-create-tag`**: the `deploy` input was `required: true` **and** had `default: 'true'` — a required input's default can never apply.

## Scope note

This does **not** validate runtime behavior (e.g. a bump that changes an action's defaults or drops a Node runtime). That needs a real run from a staging consumer. actionlint is the cheap first gate; runtime validation is a separate follow-up.