### PR TITLE
PE-47966 Scope the BuildKit registry cache per repository

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -116,7 +116,8 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           builder: builder
           cache-from: type=registry,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{
-            inputs.AWS_REGION }}.amazonaws.com/kaniko-cache
+            inputs.AWS_REGION }}.amazonaws.com/kaniko-cache:${{
+            github.event.repository.name }}
           cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{
             inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION
-            }}.amazonaws.com/kaniko-cache
+            }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}

--- a/.github/workflows/gha-auto-deploy-integration.yaml
+++ b/.github/workflows/gha-auto-deploy-integration.yaml
@@ -101,8 +101,8 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           builder: builder
-          cache-from: type=registry,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache
-          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache
+          cache-from: type=registry,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}
+          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}
 
       - uses: chrnorm/deployment-action@v2
         name: Create GitHub deployment

--- a/.github/workflows/gha-deploy-integration.yaml
+++ b/.github/workflows/gha-deploy-integration.yaml
@@ -106,8 +106,8 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           builder: builder
-          cache-from: type=registry,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache
-          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache
+          cache-from: type=registry,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}
+          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}
 
       # we will not activate GH deployment creation for a custom branch deployment for now
       - uses: chrnorm/deployment-action@v2

--- a/.github/workflows/gha-dispatcher-tag.yaml
+++ b/.github/workflows/gha-dispatcher-tag.yaml
@@ -76,5 +76,5 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           builder: builder
-          cache-from: type=registry,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache
-          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache
+          cache-from: type=registry,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}
+          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}

--- a/.github/workflows/web-qa.yaml
+++ b/.github/workflows/web-qa.yaml
@@ -99,5 +99,5 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           builder: builder
-          cache-from: type=registry,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache
-          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache
+          cache-from: type=registry,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}
+          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}

--- a/.github/workflows/web-ssr-qa.yaml
+++ b/.github/workflows/web-ssr-qa.yaml
@@ -99,5 +99,5 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           builder: builder
-          cache-from: type=registry,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache
-          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache
+          cache-from: type=registry,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}
+          cache-to: type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}


### PR DESCRIPTION
## Problem

Every reusable workflow in this repo exports its BuildKit cache to `<acct>.dkr.ecr.<region>.amazonaws.com/kaniko-cache` — no repository, no tag, so it all resolves to the single `kaniko-cache:latest`. The image ref one line above is already namespaced with `github.event.repository.name`; the cache ref was not.

15 repos build through these workflows, plus every branch and PR, and `mode=max` rewrites the whole cache index on each push. The manifest a build imports is almost always some other service's, so it matches nothing.

## Evidence (fl-backend-rails)

Five consecutive runs, three branches. Each imported a cache manifest fine and produced **0 `CACHED` layers**:

| run | branch | CACHED | `bundle install` |
|---|---|---|---|
| [30614923274](https://github.com/freeletics/fl-backend-rails/actions/runs/30614923274) | master | 0 | 128.6s |
| [30558649682](https://github.com/freeletics/fl-backend-rails/actions/runs/30558649682) | update-claude-md | 2 (`WORKDIR`) | 122.8s |
| [30552960948](https://github.com/freeletics/fl-backend-rails/actions/runs/30552960948) | translations | 0 | 131.7s |
| [30526865083](https://github.com/freeletics/fl-backend-rails/actions/runs/30526865083) | master | 0 | 131.5s |
| [30470238815](https://github.com/freeletics/fl-backend-rails/actions/runs/30470238815) | translations | 2 | 127.4s |

`Gemfile.lock` was untouched in all five, yet every gem was re-resolved and reinstalled each time. That layer is **61% of a 212s build**. Two of those runs are the same commit built concurrently by `docker.yaml` and `gha-auto-deploy-integration.yaml` — both writing `:latest` at the same instant, so this repo also poisons its own cache on every master push.

It bites Rails repos hardest because `rails-baseimage` defers `bundle install` to an `ONBUILD` trigger, so gems are never baked into the base image and registry cache is the only thing that can make them free.

## Change

Append `:${{ github.event.repository.name }}` to both cache refs in all six affected workflows. Cache tag now mirrors the image name.

Expected: 212s → ~80s on any build that doesn't touch `Gemfile.lock`.

## What does not change

- **Image names and tags are untouched.** They come from `docker/metadata-action`, whose `images:` input is already `…/${{ github.event.repository.name }}` in all six workflows. Verified against both builders of `fl-backend-rails@217ebc2`: `gha-217ebc2`, `gha-latest-master`, `gha-deploy-int-1785485002` — unchanged.
- `kaniko-cache` is a separate ECR repository and is never deployed. The only renamed artifact is the cache itself: `kaniko-cache:latest` → `kaniko-cache:<repo>`.
- Flux triggers send `docker_image_tag` derived from metadata-action — unaffected.
- An org-wide search for `kaniko-cache` returns only these `cache-from`/`cache-to` pairs, the same lines in `core-coach`/`fn`/`docker-rails-baseimage` copies, and the bare repo declaration in `tf_freeletics_cr`. Nothing consumes it as a base image or pins `:latest`.

## Risk

**The failure mode is the status quo.** Anything wrong with a cache ref produces cache misses — today's build times. No effect on image contents, tags, digests or deploy wiring. One-commit revert.

Deliberate: both fl-backend-rails builders share one tag rather than getting a discriminator each. They build the same Dockerfile from the same commit, so whichever writes last stores equivalent content. Cross-*repo* clobbering is the destructive kind, because that content is unrelated.

No staleness risk for the layer this makes cacheable: `Gemfile.lock` pins every gem including the git ones by revision, and there is no `apt-get` anywhere in the ONBUILD chain — OS packages come from the digest-pinned base image. A cache hit is byte-equivalent to a fresh install.

Two things worth a look from someone with AWS access, both pre-existing rather than introduced here:

1. `kaniko-cache: {}` carries no lifecycle config in `tf_freeletics_cr/config.yaml`. Today's constant overwriting orphans blobs; if nothing expires untagged images, growth is already unbounded and the overwriting merely hid it. After this change ~15 tags stay live, roughly 10–20 GB total (~$1–2/month), and the growth becomes visible.
2. `GEOLITE2_CACHE_BUST=$(date -u +%Y-%m-%d)` in `docker.yaml` invalidates GeoLite2 + bootsnap + `assets:precompile` on the first build of each day (~15s). Weekly would be plenty for a GeoIP DB. Left alone here to keep this diff to one concern.

## Verification

`actionlint 1.7.12` (the version CI pins) clean across all workflows. Confirmed the YAML folding in `docker.yaml`'s wrapped scalars resolves to the intended single-line ref, identical to the other five.
