### PR TITLE
PE-47984 rails CI: add runs_on input, faster postgres readiness, parallel rubocop

### DIFF
--- a/.github/workflows/rails-tests-linters.yaml
+++ b/.github/workflows/rails-tests-linters.yaml
@@ -76,14 +76,34 @@ jobs:
     outputs:
       test_job_result: ${{ steps.test_job_result.outputs.test_job_result }}
     steps:
+      - name: Identify the runner image
+        # ImageVersion is a machine environment variable, not part of the env
+        # context, so it has to be surfaced as a step output to be usable in a
+        # cache key below.
+        if: inputs.runs_on != 'ubuntu-22.04'
+        id: runner_image
+        run: echo "version=${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
       - name: Restore cached runner packages
         # Only images other than ubuntu-22.04 x64 are missing packages, so
         # default consumers skip the cache probe entirely.
+        #
+        # The key includes the runner image version deliberately, and there are
+        # no restore-keys. actions/cache does not re-save on an exact primary
+        # key hit ("Cache hit occurred on the primary key ..., not saving
+        # cache"), so a key that never changes would freeze these debs until
+        # someone manually bumped it. Keying on the image means the packages
+        # refresh exactly when the thing they have to be installable on changes,
+        # and a stale entry can no longer outlive its image. Cost is one ~20s
+        # apt run per runner image release, then cached again.
+        #
+        # restore-keys would defeat that: a successful install from carried-over
+        # debs means they are never re-downloaded, and they would then be saved
+        # again under the new image's key.
         if: inputs.runs_on != 'ubuntu-22.04'
         uses: actions/cache@v4
         with:
           path: ~/.ci-debs
-          key: rails-ci-debs-${{ inputs.runs_on }}-v1
+          key: rails-ci-debs-${{ inputs.runs_on }}-${{ steps.runner_image.outputs.version }}-v1
       - name: Ensure ImageMagick and psql are present
         run: |
           # No-op on ubuntu-22.04 x64, which ships both. The arm images ship

--- a/.github/workflows/rails-tests-linters.yaml
+++ b/.github/workflows/rails-tests-linters.yaml
@@ -33,6 +33,16 @@ on:
         required: false
         type: string
         default: "postgres:16"
+      rubocop_parallel:
+        description: >-
+          Pass --parallel to rubocop. Opt-in, because it only pays off where the
+          runner has more than one physical core. Measured paired on the same
+          runner: ubuntu-22.04-arm 92s -> 58s, but ubuntu-22.04 76s -> 73s, which
+          is inside the noise. A standard x64 runner is two hyperthreads of one
+          core, so a second rubocop worker has nothing to run on.
+        required: false
+        type: string
+        default: "false"
       runs_on:
         description: >-
           Runner label for both jobs. ubuntu-22.04-arm measured ~33% faster on
@@ -72,17 +82,25 @@ jobs:
           --health-cmd pg_isready
           --health-interval 2s
           --health-timeout 5s
-          --health-retries 30
+          --health-retries 75
     outputs:
       test_job_result: ${{ steps.test_job_result.outputs.test_job_result }}
     steps:
       - name: Identify the runner image
         # ImageVersion is a machine environment variable, not part of the env
-        # context, so it has to be surfaced as a step output to be usable in a
-        # cache key below.
+        # context, so it has to be surfaced as a step output to be usable in the
+        # cache key below. If it is ever absent (self-hosted label, future runner
+        # change) fall back to the date, not a constant: a constant key can never
+        # be re-saved once it exists, so it would freeze the packages for good.
+        #
+        # Creating the directory here as well means the cache path always exists,
+        # so the post-job save cannot warn "Path(s) specified in the action for
+        # caching do(es) not exist" on an image that happens to ship both tools.
         if: inputs.runs_on != 'ubuntu-22.04'
         id: runner_image
-        run: echo "version=${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
+        run: |
+          mkdir -p ~/.ci-debs
+          echo "version=${ImageVersion:-$(date -u +%Y-%m-%d)}" >> "$GITHUB_OUTPUT"
       - name: Restore cached runner packages
         # Only images other than ubuntu-22.04 x64 are missing packages, so
         # default consumers skip the cache probe entirely.
@@ -92,13 +110,18 @@ jobs:
         # key hit ("Cache hit occurred on the primary key ..., not saving
         # cache"), so a key that never changes would freeze these debs until
         # someone manually bumped it. Keying on the image means the packages
-        # refresh exactly when the thing they have to be installable on changes,
-        # and a stale entry can no longer outlive its image. Cost is one ~20s
-        # apt run per runner image release, then cached again.
+        # refresh when the thing they have to be installable on changes. Cost is
+        # one ~20s apt run per runner image release, then cached again.
         #
         # restore-keys would defeat that: a successful install from carried-over
         # debs means they are never re-downloaded, and they would then be saved
         # again under the new image's key.
+        #
+        # Known limitation: GitHub cache entries are immutable per key, so a
+        # corrupt or partial entry cannot be replaced under the same key. The
+        # install step below falls back to plain apt, so CI keeps working, but it
+        # pays the full ~20s every run until the next image bump changes the key.
+        # Bump the -v1 suffix to force it sooner.
         if: inputs.runs_on != 'ubuntu-22.04'
         uses: actions/cache@v4
         with:
@@ -120,15 +143,28 @@ jobs:
             # download itself, which is only ~1s for ~1.3MB.
             if ls ~/.ci-debs/*.deb >/dev/null 2>&1; then
               echo "Installing$NEED from cached debs"
-              sudo dpkg -i ~/.ci-debs/*.deb >/dev/null 2>&1 || true
+              # Output is deliberately not silenced: when this fails it is the
+              # only clue. A half-applied dpkg leaves packages unconfigured and
+              # would make the apt fallback below die on "dpkg was interrupted",
+              # so recover before falling through.
+              sudo dpkg -i ~/.ci-debs/*.deb || sudo dpkg --configure -a || true
             fi
             if ! (command -v psql >/dev/null && { command -v convert >/dev/null || command -v magick >/dev/null; }); then
               echo "Fetching runner packages:$NEED"
               rm -rf ~/.ci-debs && mkdir -p ~/.ci-debs/partial
-              sudo apt-get update -qq
+              # apt mirrors on hosted runners intermittently 403 or report a hash
+              # mismatch. Without a retry that is a hard job failure, and every
+              # opted-in repo hits this same path at once on an image bump.
+              for attempt in 1 2 3; do
+                sudo apt-get update -qq && break
+                echo "apt-get update failed (attempt $attempt), retrying"
+                sleep 5
+              done
               sudo apt-get install -y -qq --download-only -o Dir::Cache::archives="$HOME/.ci-debs" $NEED
-              sudo chown -R "$USER" ~/.ci-debs && rm -rf ~/.ci-debs/partial ~/.ci-debs/lock
-              sudo dpkg -i ~/.ci-debs/*.deb >/dev/null 2>&1 || sudo apt-get install -y -qq $NEED
+              # id -un rather than $USER: the latter is unset in some contexts and
+              # chown -R "" fails the step after the download already succeeded.
+              sudo chown -R "$(id -un)" ~/.ci-debs && rm -rf ~/.ci-debs/partial ~/.ci-debs/lock
+              sudo dpkg -i ~/.ci-debs/*.deb || { sudo dpkg --configure -a || true; sudo apt-get install -y -qq $NEED; }
             fi
           fi
           command -v convert >/dev/null || command -v magick >/dev/null || { echo "ImageMagick not available"; exit 1; }
@@ -145,10 +181,24 @@ jobs:
         name: Prepare ruby environment
         with:
           bundler-cache: true
-      - name: Set up database
+      - name: Wait for postgres to accept connections
         run: |
-          # diagnostic only; 24.04/arm images do not ship the postgres client
-          pg_config --version || echo "pg_config not on PATH (not required)"
+          # The service is marked healthy by a container-internal pg_isready,
+          # which can succeed against the temporary server the official postgres
+          # image runs during initdb with listen_addresses='' - i.e. before TCP
+          # 5432 is listening. At a 10s interval the first probe almost always
+          # landed after the real server was up; at 2s it can land inside that
+          # window. Checking from the host closes it, so the first real query
+          # cannot hit "the database system is starting up".
+          #
+          # This replaces a step named "Set up database" that only ran
+          # `pg_config --version` as a diagnostic and set nothing up.
+          for _ in $(seq 1 60); do
+            pg_isready -h "${PGHOST:-127.0.0.1}" -p 5432 -q && exit 0
+            sleep 1
+          done
+          echo "postgres did not start accepting connections within 60s"
+          exit 1
       - name: Load database schema
         run: |
           echo "parallel_test_enabled" ${{  inputs.parallel_test_enabled }}
@@ -186,10 +236,16 @@ jobs:
         with:
           bundler-cache: true
       - name: Lint Ruby files
-        # --parallel measured 96s -> 51s on ubuntu-22.04-arm (n=3 each, ranges
-        # do not overlap). Worth it even on 2-core runners. Note it is silently
-        # ignored if --cache false is ever added.
-        run: bundle exec rubocop -D -c .rubocop.yml --parallel
+        # Opt-in via rubocop_parallel, because the gain depends on the runner
+        # having real cores: measured paired on one runner, ubuntu-22.04-arm goes
+        # 92s -> 58s while ubuntu-22.04 goes 76s -> 73s, i.e. nothing. Note
+        # --parallel is silently ignored if --cache false is ever added, and that
+        # rubocop caches results between runs, so a second run in the same job
+        # completes in ~3s regardless of mode and cannot be used to compare them.
+        run: |
+          FLAGS=""
+          if [ "${{ inputs.rubocop_parallel }}" = "true" ]; then FLAGS="--parallel"; fi
+          bundle exec rubocop -D -c .rubocop.yml $FLAGS
       - name: Set Linters result
         id: linters_job_result
         run: echo "linters_job_result=${{job.status}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/rails-tests-linters.yaml
+++ b/.github/workflows/rails-tests-linters.yaml
@@ -33,6 +33,16 @@ on:
         required: false
         type: string
         default: "postgres:16"
+      runs_on:
+        description: >-
+          Runner label for both jobs. ubuntu-22.04-arm measured ~33% faster on
+          rspec than ubuntu-22.04 for fl-backend-rails, and removes the x64
+          CPU lottery (x64 standard runners draw from a mixed Zen3/Zen4/Xeon
+          fleet, giving a ~70% spread run to run; the arm fleet is uniform).
+          Opt in per repo: native gems must build on aarch64.
+        required: false
+        type: string
+        default: "ubuntu-22.04"
 
 env:
   BUNDLE_GITHUB__COM: "${{ secrets.PRIVATE_GEMS_SECRET }}:x-oauth-basic"
@@ -44,7 +54,7 @@ env:
 jobs:
   Tests:
     # You must use a Linux environment when using service containers or container jobs
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runs_on }}
     timeout-minutes: ${{ inputs.rails_test_timeout_minutes || fromJSON(vars.BE_JOB_TIMEOUT || vars.DEFAULT_JOB_TIMEOUT) }}
     env:
       RAILS_ENV: test
@@ -60,14 +70,49 @@ jobs:
           - 5432:5432
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 2s
           --health-timeout 5s
-          --health-retries 15
+          --health-retries 30
     outputs:
       test_job_result: ${{ steps.test_job_result.outputs.test_job_result }}
     steps:
-      - name: Verify ImageMagick is available
-        run: command -v convert >/dev/null || command -v magick >/dev/null || { echo "ImageMagick not found on the runner image"; exit 1; }
+      - name: Restore cached runner packages
+        # Only images other than ubuntu-22.04 x64 are missing packages, so
+        # default consumers skip the cache probe entirely.
+        if: inputs.runs_on != 'ubuntu-22.04'
+        uses: actions/cache@v4
+        with:
+          path: ~/.ci-debs
+          key: rails-ci-debs-${{ inputs.runs_on }}-v1
+      - name: Ensure ImageMagick and psql are present
+        run: |
+          # No-op on ubuntu-22.04 x64, which ships both. The arm images ship
+          # ImageMagick but no postgres client, and the 24.04 images ship
+          # neither (dropped to stay inside the runner free-disk SLA,
+          # actions/runner-images#10772). psql is required whenever the schema
+          # is SQL-format, since structure.sql is loaded by shelling out to it.
+          NEED=""
+          command -v convert >/dev/null || command -v magick >/dev/null || NEED="$NEED imagemagick"
+          command -v psql >/dev/null || NEED="$NEED postgresql-client"
+          if [ -n "$NEED" ]; then
+            # dpkg -i on pre-fetched debs takes ~3s; the full apt path takes
+            # 13-21s. The saving is skipping update/resolve/triggers, not the
+            # download itself, which is only ~1s for ~1.3MB.
+            if ls ~/.ci-debs/*.deb >/dev/null 2>&1; then
+              echo "Installing$NEED from cached debs"
+              sudo dpkg -i ~/.ci-debs/*.deb >/dev/null 2>&1 || true
+            fi
+            if ! (command -v psql >/dev/null && { command -v convert >/dev/null || command -v magick >/dev/null; }); then
+              echo "Fetching runner packages:$NEED"
+              rm -rf ~/.ci-debs && mkdir -p ~/.ci-debs/partial
+              sudo apt-get update -qq
+              sudo apt-get install -y -qq --download-only -o Dir::Cache::archives="$HOME/.ci-debs" $NEED
+              sudo chown -R "$USER" ~/.ci-debs && rm -rf ~/.ci-debs/partial ~/.ci-debs/lock
+              sudo dpkg -i ~/.ci-debs/*.deb >/dev/null 2>&1 || sudo apt-get install -y -qq $NEED
+            fi
+          fi
+          command -v convert >/dev/null || command -v magick >/dev/null || { echo "ImageMagick not available"; exit 1; }
+          command -v psql >/dev/null || { echo "psql not available"; exit 1; }
       - name: Skip Duplicate Actions
         uses: fkirc/skip-duplicate-actions@v5.3.2
         with:
@@ -82,7 +127,8 @@ jobs:
           bundler-cache: true
       - name: Set up database
         run: |
-          pg_config --version
+          # diagnostic only; 24.04/arm images do not ship the postgres client
+          pg_config --version || echo "pg_config not on PATH (not required)"
       - name: Load database schema
         run: |
           echo "parallel_test_enabled" ${{  inputs.parallel_test_enabled }}
@@ -105,7 +151,7 @@ jobs:
         run: echo "test_job_result=${{job.status}}" >> $GITHUB_OUTPUT
   Linters:
     timeout-minutes: ${{ inputs.rails_linter_timeout_minutes || fromJSON(vars.BE_JOB_TIMEOUT || vars.DEFAULT_JOB_TIMEOUT)}}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runs_on }}
     outputs:
       linters_job_result: ${{ steps.linters_job_result.outputs.linters_job_result }}
     env:
@@ -120,7 +166,10 @@ jobs:
         with:
           bundler-cache: true
       - name: Lint Ruby files
-        run: bundle exec rubocop -D -c .rubocop.yml
+        # --parallel measured 96s -> 51s on ubuntu-22.04-arm (n=3 each, ranges
+        # do not overlap). Worth it even on 2-core runners. Note it is silently
+        # ignored if --cache false is ever added.
+        run: bundle exec rubocop -D -c .rubocop.yml --parallel
       - name: Set Linters result
         id: linters_job_result
         run: echo "linters_job_result=${{job.status}}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Shared workflow change. **Consumed by all 7 backend Rails repos**, so please read the "applies to everyone" section.

Ticket: https://freeletics.atlassian.net/browse/PE-47984

## What this enables

The headline finding: **a standard x64 GitHub runner's "2 vCPU" are two hyperthreads of ONE physical core.** `lscpu` reports Thread(s) per core 2, Core(s) per socket 1, and both vCPUs share `core id 0`. Two concurrent busy loops take 2x wall time on x64 and 1x on ARM.

That single fact explains a lot of previously confusing CI behaviour, and it means ARM's value is not clock speed — it is that parallelism actually works there.

Measured on the two repos where it matters:

| repo | before (x64) | after (ARM, +parallel where noted) |
|---|---|---|
| fl-backend-rails | rspec 319s median (200–344) | **167s** |
| core-payment-rails | 110s serial | **72s** with `-n 2` |
| core-user-rails | 68s serial median (56–109, n=16) | **40s** with `-n 2` |

Run-to-run spread also collapses (fl-backend-rails 1.7x → ~1.2x; core-user-rails 1.9x → 1.14x), because the x64 fleet dispatches from a mixed EPYC 7763 / EPYC 9V74 / Xeon 8573C / Xeon 6973P-C pool while the ARM fleet is uniform.

## Opt-in: the runs_on input

Defaults to `ubuntu-22.04`, so **no consumer changes behaviour unless it sets the input.** The arm and 24.04 images ship no postgres client (and the 24.04 ones no ImageMagick — dropped for the runner free-disk SLA, actions/runner-images#10772), so the workflow installs what is missing and caches the `.deb` files: `dpkg -i` on cached debs is ~2s against 13–21s for a full apt path. That cache step is **skipped entirely on the default runner**, where both packages are preinstalled.

## Applies to everyone — please review these three

1. **`--health-interval 2s` for postgres** (was 10s, retries 15 → 30 to keep the same window). Container init ~21s → ~8.5s, n=4 each, non-overlapping. Benefits the small repos proportionally most: `core-gem` runs 4 seconds of tests inside a 45 second job.
2. **`rubocop --parallel`.** Measured 96s → 51s on ARM, n=3 each, non-overlapping. Note an earlier x64 measurement was inconclusive because the mixed x64 fleet swings rubocop 65–102s on its own. Identical offences; verified byte-identical output.
3. **ImageMagick check is now install-if-missing rather than fail-if-missing**, and **`pg_config --version` is non-fatal** (diagnostic only). Both are no-ops on `ubuntu-22.04` x64. Worth a conscious decision: a future image dropping ImageMagick would now self-heal rather than fail loudly.

If you would rather gate `--parallel` behind its own input, that is a one-line change — say so and I will add it.

## Consumers ready to opt in

* freeletics/fl-backend-rails#12634 — **its `uses:` is pinned to this branch for validation and must be reverted to `@main` before merge**
* freeletics/core-payment-rails#4034 — currently `startup_failure` because it passes inputs that do not exist on `main` yet; it will go green once this merges
* freeletics/core-user-rails#4789 — spec robustness fixes, independent of this PR, mergeable now

## Not included

`--group-by runtime` for parallel shards was prototyped and validated here (shard imbalance 10.6s → 3.4s) then reverted, because re-splitting the shards exposes a latent factory bug in fl-backend-rails. Tracked as PE-47987, blocked by PE-47985.