### PR TITLE
Disable Spring in Rails CI

### DIFF
--- a/.github/workflows/rails-tests-linters.yaml
+++ b/.github/workflows/rails-tests-linters.yaml
@@ -60,6 +60,13 @@ env:
   PGHOST: 127.0.0.1
   PGUSER: postgres
   PGPASSWORD: postgres
+  # Spring is a development preloader; in CI every command runs once in a fresh
+  # container, so the spring server it forks is pure overhead. It also blocks
+  # `config.enable_reloading = false` in test.rb — Spring raises rather than
+  # preload without the reloader, and repos whose bin/rails is springified hit
+  # that on `rails db:create`. Bundler puts ./bin on PATH, so `bundle exec rails`
+  # picks up the springified binstub too.
+  DISABLE_SPRING: "1"
 
 jobs:
   Tests:

--- a/.github/workflows/rails-tests-linters.yaml
+++ b/.github/workflows/rails-tests-linters.yaml
@@ -64,8 +64,9 @@ env:
   # container, so the spring server it forks is pure overhead. It also blocks
   # `config.enable_reloading = false` in test.rb — Spring raises rather than
   # preload without the reloader, and repos whose bin/rails is springified hit
-  # that on `rails db:create`. Bundler puts ./bin on PATH, so `bundle exec rails`
-  # picks up the springified binstub too.
+  # that on `rails db:create`. `bundle exec rails` reaches that binstub because
+  # railties' own exe/rails re-execs ./bin/rails via Rails::AppLoader; `rake` has
+  # no such re-exec, which is why the parallel:setup path never tripped over it.
   DISABLE_SPRING: "1"
 
 jobs:


### PR DESCRIPTION
## What

Adds `DISABLE_SPRING: "1"` to the top-level `env` of the shared Rails CI workflow.

## Why

Two reasons, one of them blocking.

**1. Spring buys nothing in CI.** It is a development preloader: it forks a long-lived server so that *subsequent* commands boot fast. In CI every command runs once, in a fresh container, so we pay the fork and the extra app boot and never collect the payoff.

**2. It blocks disabling the code reloader in the test environment.** Spring registers an `:ensure_reloading_is_enabled` initializer that raises unless `config.enable_reloading` is `true`:

```
Spring reloads, and therefore needs the application to have reloading enabled.
Please, set config.enable_reloading to true in config/environments/test.rb.
```

Turning the reloader off in test is worth between 0% and 22% of suite runtime depending on the repo (paired 4-rep measurements in PE-47986: 11% payment, 10% user, 3% social, 0% messaging, 22% fl-backend-rails — it scales with the size of the autoloadable code base, not with suite length). But any repo whose `bin/rails` is springified fails at `bundle exec rails db:create` the moment `test.rb` sets `enable_reloading = false`.

`bundle exec rails` reaches that binstub not through `PATH` but through Rails itself: railties' `exe/rails` calls `Rails::AppLoader.exec_app`, which walks up for `bin/rails` and `exec`s it outright ([`app_loader.rb:53`](https://github.com/rails/rails/blob/main/railties/lib/rails/app_loader.rb)). `rake` has no equivalent re-exec, so `bundle exec rake parallel:setup` never enters `bin/rake` — which is exactly why the two parallel-path repos are immune even though fl-backend-rails' `bin/rake` *is* springified.

That is exactly the split we see today:

| repo | `bin/rails` springified | DB setup path | `enable_reloading = false` |
|---|---|---|---|
| core-payment-rails | no | `rake parallel:setup` | works |
| fl-backend-rails | yes | `rake parallel:setup` | works (never invokes `rails`) |
| core-user-rails | yes | `rails db:create` | **failed** |
| fl-backend-social | yes | `rails db:create` | **failed** |
| backend-messaging | yes | `rails db:create` | **failed** |

## How

`spring/binstub.rb` checks `ENV["DISABLE_SPRING"]` and falls through to the normal Rails boot when it is set:

```ruby
disable = ENV["DISABLE_SPRING"]
if Process.respond_to?(:fork) && (disable.nil? || disable.empty? || disable == "0")
  ARGV.unshift(command)
  load bin_path
end
```

This is Spring's own documented opt-out, so no repo needs a `config/spring.rb` change. The alternative — `Spring.dangerously_allow_disabling_reloading = true` per repo — makes Spring run *without* the reloader, which would silently serve stale code to developers running `bin/rspec` locally. Disabling Spring in CI only leaves local development untouched.

## Validation

Pinned each of the three previously-failing branches to this branch and re-ran. All green, both jobs:

| repo | run |
|---|---|
| core-user-rails | [30941746949](https://github.com/freeletics/core-user-rails/actions/runs/30941746949) ✅ |
| fl-backend-social | [30941749309](https://github.com/freeletics/fl-backend-social/actions/runs/30941749309) ✅ |
| backend-messaging | [30941753666](https://github.com/freeletics/backend-messaging/actions/runs/30941753666) ✅ |

The pins have since been reverted to `@main`; those branches now wait on this PR.

Repos already on the parallel path (fl-backend-rails, core-payment-rails) are unaffected either way — they never invoked the springified binstub — but they stop forking a pointless spring server too.

PE-47986
