### PR TITLE
perf(web-astro): compress the build artifact with zstd instead of gzip (PE-48093)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -62,10 +62,28 @@ jobs:
           name: ${{ inputs.ARTIFACTS_NAME }}
           path: ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}
 
+      # Accepts either `.tar.zst` or `.tar.gz`, picking whichever the
+      # producing workflow actually uploaded. Detection rather than a
+      # swap, because this workflow is shared by 16 repos and every
+      # existing caller uploads gzip — they keep working untouched.
+      # zstd is preinstalled on the GitHub-hosted ubuntu images.
       - name: Uncompress Artifacts
         if: ${{ inputs.ARTIFACTS_COMPRESSED == true }}
-        run: tar -xzf ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}/${{
-          inputs.ARTIFACTS_NAME }}.tar.gz -C ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          DIR="${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}"
+          NAME="${{ inputs.ARTIFACTS_NAME }}"
+          if [ -f "$DIR/$NAME.tar.zst" ]; then
+            echo "Extracting $NAME.tar.zst (zstd)"
+            zstd -dc "$DIR/$NAME.tar.zst" | tar -xf - -C "${{ github.workspace }}"
+          elif [ -f "$DIR/$NAME.tar.gz" ]; then
+            echo "Extracting $NAME.tar.gz (gzip)"
+            tar -xzf "$DIR/$NAME.tar.gz" -C "${{ github.workspace }}"
+          else
+            echo "::error::No $NAME.tar.zst or $NAME.tar.gz found in $DIR"
+            ls -la "$DIR" || true
+            exit 1
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.2.3

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -62,28 +62,20 @@ jobs:
           name: ${{ inputs.ARTIFACTS_NAME }}
           path: ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}
 
-      # Accepts either `.tar.zst` or `.tar.gz`, picking whichever the
-      # producing workflow actually uploaded. Detection rather than a
-      # swap, because this workflow is shared by 16 repos and every
-      # existing caller uploads gzip — they keep working untouched.
-      # zstd is preinstalled on the GitHub-hosted ubuntu images.
+      # `tar -xf` auto-detects the compression format, so this handles
+      # `.tar.gz` (every caller today) and `.tar.zst` (web-astro, PE-48093)
+      # without naming either.
       - name: Uncompress Artifacts
         if: ${{ inputs.ARTIFACTS_COMPRESSED == true }}
+        env:
+          DIR: ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}
+          NAME: ${{ inputs.ARTIFACTS_NAME }}
+          WORKSPACE: ${{ github.workspace }}
         run: |
           set -euo pipefail
-          DIR="${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}"
-          NAME="${{ inputs.ARTIFACTS_NAME }}"
-          if [ -f "$DIR/$NAME.tar.zst" ]; then
-            echo "Extracting $NAME.tar.zst (zstd)"
-            zstd -dc "$DIR/$NAME.tar.zst" | tar -xf - -C "${{ github.workspace }}"
-          elif [ -f "$DIR/$NAME.tar.gz" ]; then
-            echo "Extracting $NAME.tar.gz (gzip)"
-            tar -xzf "$DIR/$NAME.tar.gz" -C "${{ github.workspace }}"
-          else
-            echo "::error::No $NAME.tar.zst or $NAME.tar.gz found in $DIR"
-            ls -la "$DIR" || true
-            exit 1
-          fi
+          ARCHIVE=$(find "$DIR" -maxdepth 1 -name "$NAME.tar.*" -print -quit)
+          [ -n "$ARCHIVE" ] || { echo "::error::No $NAME.tar.* in $DIR"; ls -la "$DIR"; exit 1; }
+          tar -xf "$ARCHIVE" -C "$WORKSPACE"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.2.3

--- a/.github/workflows/gha-auto-deploy-integration.yaml
+++ b/.github/workflows/gha-auto-deploy-integration.yaml
@@ -57,9 +57,20 @@ jobs:
           name: ${{ inputs.ARTIFACTS_NAME }}
           path: ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}
 
+      # `tar -xf` auto-detects the compression format, so this handles
+      # `.tar.gz` (every caller today) and `.tar.zst` (web-astro, PE-48093)
+      # without naming either.
       - name: Uncompress Artifacts
         if: ${{ inputs.ARTIFACTS_COMPRESSED == true }}
-        run: tar -xzf ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}/${{ inputs.ARTIFACTS_NAME }}.tar.gz -C ${{ github.workspace }}
+        env:
+          DIR: ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}
+          NAME: ${{ inputs.ARTIFACTS_NAME }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          ARCHIVE=$(find "$DIR" -maxdepth 1 -name "$NAME.tar.*" -print -quit)
+          [ -n "$ARCHIVE" ] || { echo "::error::No $NAME.tar.* in $DIR"; ls -la "$DIR"; exit 1; }
+          tar -xf "$ARCHIVE" -C "$WORKSPACE"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.2.3

--- a/.github/workflows/gha-deploy-integration.yaml
+++ b/.github/workflows/gha-deploy-integration.yaml
@@ -62,9 +62,20 @@ jobs:
           name: ${{ inputs.ARTIFACTS_NAME }}
           path: ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}
 
+      # `tar -xf` auto-detects the compression format, so this handles
+      # `.tar.gz` (every caller today) and `.tar.zst` (web-astro, PE-48093)
+      # without naming either.
       - name: Uncompress Artifacts
         if: ${{ inputs.ARTIFACTS_COMPRESSED == true }}
-        run: tar -xzf ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}/${{ inputs.ARTIFACTS_NAME }}.tar.gz -C ${{ github.workspace }}
+        env:
+          DIR: ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}
+          NAME: ${{ inputs.ARTIFACTS_NAME }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          ARCHIVE=$(find "$DIR" -maxdepth 1 -name "$NAME.tar.*" -print -quit)
+          [ -n "$ARCHIVE" ] || { echo "::error::No $NAME.tar.* in $DIR"; ls -la "$DIR"; exit 1; }
+          tar -xf "$ARCHIVE" -C "$WORKSPACE"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.2.3

--- a/.github/workflows/web-astro.yaml
+++ b/.github/workflows/web-astro.yaml
@@ -155,38 +155,17 @@ jobs:
           CI: "false"
           APP_ENV: "${{ env.APP_ENV }}"
 
-      # zstd rather than gzip. Measured on 745 MB / ~15k files over 3
-      # replicates per arch (PE-48093, run 31191398581):
+      # zstd, not gzip: 13-17x faster and 5x smaller (PE-48093).
       #
-      #   gzip -6 (was)   18.2s x64 / 13.3s ARM -> 168 MB
-      #   zstd -3 -T0     1.4s  x64 /  0.8s ARM ->  32 MB
-      #
-      # 13-17x faster AND 5x smaller. gzip's 32 KB window cannot dedupe
-      # across files; the blog's ~15k pages share layout, nav, inline CSS
-      # and JSON-LD, and zstd's much larger window exploits that. The
-      # smaller artifact also cuts upload here and download in the docker
-      # job, which untars either format (see docker.yaml).
-      #
-      # `set -o pipefail` is load-bearing: GitHub's default shell is
-      # `bash -e`, which does NOT set it, so a failing `tar` would be
-      # masked by zstd exiting 0 and we would upload a truncated artifact
-      # that only surfaces as a broken deploy. Verified: without pipefail
-      # that pipeline exits 0 leaving a 45-byte "archive".
-      #
-      # zstd is preinstalled on the GitHub-hosted ubuntu images (x64 and
-      # arm64); the fallback keeps a missing binary from breaking a build.
+      # `pipefail` is load-bearing — GitHub's default shell is `bash -e`,
+      # which does NOT set it, so a failing `tar` would be masked by zstd
+      # exiting 0 and we would upload a truncated artifact that only
+      # surfaces as a broken deploy.
       - name: Compress Artifacts
         run: |
           set -euo pipefail
-          if command -v zstd >/dev/null 2>&1; then
-            tar -cf - "${{ inputs.BUILD_OUTPUT_DIR }}" | zstd -3 -T0 -q -o public.tar.zst
-            zstd -t public.tar.zst
-            ls -lh public.tar.zst
-          else
-            echo "::warning::zstd not found on this runner image — falling back to gzip"
-            tar -czf public.tar.gz "${{ inputs.BUILD_OUTPUT_DIR }}"
-            ls -lh public.tar.gz
-          fi
+          tar -cf - "${{ inputs.BUILD_OUTPUT_DIR }}" | zstd -3 -T0 -qf -o public.tar.zst
+          zstd -t public.tar.zst
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v7
@@ -194,10 +173,8 @@ jobs:
           name: public
           path: |
             public.tar.zst
-            public.tar.gz
-          # The tarball is already compressed. upload-artifact zips its
-          # input by default, so the default level burns CPU recompressing
-          # compressed data for no size gain — measured 7s -> 3s (PE-48093).
+          # Already compressed; upload-artifact zips its input by default,
+          # which recompresses compressed data for no gain (7s -> 3s).
           compression-level: 0
           if-no-files-found: error
           retention-days: 5

--- a/.github/workflows/web-astro.yaml
+++ b/.github/workflows/web-astro.yaml
@@ -155,8 +155,26 @@ jobs:
           CI: "false"
           APP_ENV: "${{ env.APP_ENV }}"
 
+      # `pigz` is parallel gzip — same output format, so the docker job's
+      # `tar -xzf` is unchanged, but it uses both runner cores instead of
+      # one. Measured on 745 MB / ~15k files (PE-48093, 3 reps per arch):
+      # 18.2s -> 11.5s on x64, 13.3s -> 6.8s on ARM. Falls back to plain
+      # gzip if a future runner image ever drops pigz.
+      #
+      # `set -o pipefail` is load-bearing: the default GitHub shell is
+      # `bash -e`, which does NOT set it, so a failing `tar` in the
+      # pipeline would be masked by pigz exiting 0 and we would upload a
+      # truncated artifact that only surfaces as a broken deploy.
       - name: Compress Artifacts
-        run: tar -czf public.tar.gz "${{ inputs.BUILD_OUTPUT_DIR }}"
+        run: |
+          set -euo pipefail
+          if command -v pigz >/dev/null 2>&1; then
+            tar -cf - "${{ inputs.BUILD_OUTPUT_DIR }}" | pigz > public.tar.gz
+          else
+            echo "::warning::pigz not found on this runner image — falling back to single-threaded gzip"
+            tar -czf public.tar.gz "${{ inputs.BUILD_OUTPUT_DIR }}"
+          fi
+          ls -lh public.tar.gz
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v7
@@ -164,6 +182,10 @@ jobs:
           name: public
           path: |
             public.tar.gz
+          # The tarball is already gzipped. upload-artifact zips its input
+          # by default, so the default level burns CPU re-compressing
+          # compressed data for no size gain — measured 7s -> 3s (PE-48093).
+          compression-level: 0
           retention-days: 5
 
   docker:

--- a/.github/workflows/web-astro.yaml
+++ b/.github/workflows/web-astro.yaml
@@ -155,37 +155,51 @@ jobs:
           CI: "false"
           APP_ENV: "${{ env.APP_ENV }}"
 
-      # `pigz` is parallel gzip — same output format, so the docker job's
-      # `tar -xzf` is unchanged, but it uses both runner cores instead of
-      # one. Measured on 745 MB / ~15k files (PE-48093, 3 reps per arch):
-      # 18.2s -> 11.5s on x64, 13.3s -> 6.8s on ARM. Falls back to plain
-      # gzip if a future runner image ever drops pigz.
+      # zstd rather than gzip. Measured on 745 MB / ~15k files over 3
+      # replicates per arch (PE-48093, run 31191398581):
       #
-      # `set -o pipefail` is load-bearing: the default GitHub shell is
-      # `bash -e`, which does NOT set it, so a failing `tar` in the
-      # pipeline would be masked by pigz exiting 0 and we would upload a
-      # truncated artifact that only surfaces as a broken deploy.
+      #   gzip -6 (was)   18.2s x64 / 13.3s ARM -> 168 MB
+      #   zstd -3 -T0     1.4s  x64 /  0.8s ARM ->  32 MB
+      #
+      # 13-17x faster AND 5x smaller. gzip's 32 KB window cannot dedupe
+      # across files; the blog's ~15k pages share layout, nav, inline CSS
+      # and JSON-LD, and zstd's much larger window exploits that. The
+      # smaller artifact also cuts upload here and download in the docker
+      # job, which untars either format (see docker.yaml).
+      #
+      # `set -o pipefail` is load-bearing: GitHub's default shell is
+      # `bash -e`, which does NOT set it, so a failing `tar` would be
+      # masked by zstd exiting 0 and we would upload a truncated artifact
+      # that only surfaces as a broken deploy. Verified: without pipefail
+      # that pipeline exits 0 leaving a 45-byte "archive".
+      #
+      # zstd is preinstalled on the GitHub-hosted ubuntu images (x64 and
+      # arm64); the fallback keeps a missing binary from breaking a build.
       - name: Compress Artifacts
         run: |
           set -euo pipefail
-          if command -v pigz >/dev/null 2>&1; then
-            tar -cf - "${{ inputs.BUILD_OUTPUT_DIR }}" | pigz > public.tar.gz
+          if command -v zstd >/dev/null 2>&1; then
+            tar -cf - "${{ inputs.BUILD_OUTPUT_DIR }}" | zstd -3 -T0 -q -o public.tar.zst
+            zstd -t public.tar.zst
+            ls -lh public.tar.zst
           else
-            echo "::warning::pigz not found on this runner image — falling back to single-threaded gzip"
+            echo "::warning::zstd not found on this runner image — falling back to gzip"
             tar -czf public.tar.gz "${{ inputs.BUILD_OUTPUT_DIR }}"
+            ls -lh public.tar.gz
           fi
-          ls -lh public.tar.gz
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v7
         with:
           name: public
           path: |
+            public.tar.zst
             public.tar.gz
-          # The tarball is already gzipped. upload-artifact zips its input
-          # by default, so the default level burns CPU re-compressing
+          # The tarball is already compressed. upload-artifact zips its
+          # input by default, so the default level burns CPU recompressing
           # compressed data for no size gain — measured 7s -> 3s (PE-48093).
           compression-level: 0
+          if-no-files-found: error
           retention-days: 5
 
   docker:

--- a/.github/workflows/web-astro.yaml
+++ b/.github/workflows/web-astro.yaml
@@ -2,10 +2,10 @@ name: "Astro Build with Docker Kaniko"
 
 # Reusable build workflow for static Astro (Bun) sites such as
 # freeletics-web-astro. Counterpart to `web-blog.yaml` (Gatsby/yarn) and
-# `web.yaml` (Vite/pnpm). Produces the same artifact contract as those
-# workflows (a `public.tar.gz` archive uploaded under the artifact name
-# `public`) so the downstream docker/integration/QA workflows can be
-# reused without modification.
+# `web.yaml` (Vite/pnpm). Uploads a `public.tar.zst` archive under the
+# artifact name `public`; the downstream docker/integration/QA workflows
+# extract with `tar -xf`, which auto-detects the format, so they accept
+# the `.tar.gz` those sibling workflows still produce too.
 #
 # Consumer responsibilities
 # -------------------------

--- a/.github/workflows/web-qa.yaml
+++ b/.github/workflows/web-qa.yaml
@@ -56,9 +56,20 @@ jobs:
           name: ${{ inputs.ARTIFACTS_NAME }}
           path: ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}
 
+      # `tar -xf` auto-detects the compression format, so this handles
+      # `.tar.gz` (every caller today) and `.tar.zst` (web-astro, PE-48093)
+      # without naming either.
       - name: Uncompress Artifacts
         if: ${{ inputs.ARTIFACTS_COMPRESSED == true }}
-        run: tar -xzf ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}/${{ inputs.ARTIFACTS_NAME }}.tar.gz -C ${{ github.workspace }}
+        env:
+          DIR: ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}
+          NAME: ${{ inputs.ARTIFACTS_NAME }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          ARCHIVE=$(find "$DIR" -maxdepth 1 -name "$NAME.tar.*" -print -quit)
+          [ -n "$ARCHIVE" ] || { echo "::error::No $NAME.tar.* in $DIR"; ls -la "$DIR"; exit 1; }
+          tar -xf "$ARCHIVE" -C "$WORKSPACE"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.2.3

--- a/.github/workflows/web-ssr-qa.yaml
+++ b/.github/workflows/web-ssr-qa.yaml
@@ -56,9 +56,20 @@ jobs:
           name: ${{ inputs.ARTIFACTS_NAME }}
           path: ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}
 
+      # `tar -xf` auto-detects the compression format, so this handles
+      # `.tar.gz` (every caller today) and `.tar.zst` (web-astro, PE-48093)
+      # without naming either.
       - name: Uncompress Artifacts
         if: ${{ inputs.ARTIFACTS_COMPRESSED == true }}
-        run: tar -xzf ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}/${{ inputs.ARTIFACTS_NAME }}.tar.gz -C ${{ github.workspace }}
+        env:
+          DIR: ${{ github.workspace }}/${{ inputs.ARTIFACTS_NAME }}
+          NAME: ${{ inputs.ARTIFACTS_NAME }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          ARCHIVE=$(find "$DIR" -maxdepth 1 -name "$NAME.tar.*" -print -quit)
+          [ -n "$ARCHIVE" ] || { echo "::error::No $NAME.tar.* in $DIR"; ls -la "$DIR"; exit 1; }
+          tar -xf "$ARCHIVE" -C "$WORKSPACE"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.2.3


### PR DESCRIPTION
Closes **PE-48093**. Replaces gzip with **zstd** for the web-astro build artifact, and stops compressing it twice.

## Measured

3 replicates per architecture, all variants back-to-back **within one job** so the heterogeneous x64 CPU fleet can't skew the comparison ([run 31191398581](https://github.com/freeletics/freeletics-web-astro/actions/runs/31191398581)), on 745 MB / ~15,100 files:

| Variant | x64 | ARM | Output |
| --- | --- | --- | --- |
| **`gzip -6` (before)** | **18.2s** | **13.3s** | **168 MB** |
| **`zstd -3 -T0` (this PR)** | **1.4s** | **0.8s** | **32 MB** |
| `pigz -6` (considered) | 11.5s | 6.8s | 168 MB |

**13× faster on x64, 17× on ARM, and the artifact is 5× smaller.** The size win compounds — less to upload here, less to download in the docker job.

Plus `compression-level: 0` on the upload: `upload-artifact@v7` zips its input by default, so an already-compressed tarball was being compressed *again* for zero size gain. **7s → 3s.**

## Why zstd wins so heavily

gzip's window is 32 KB, so it cannot exploit redundancy *across* files. The blog's ~15k pages share layout, nav, inline CSS and JSON-LD structure, and zstd's much larger window deduplicates across them.

Output sizes are **byte-identical across architectures**, which is the sanity check that the measurement is sound — the ratio is a property of the compressor, not the CPU.

## docker.yaml detects the format, it does not switch

`docker.yaml` is consumed by **16 repos** and every existing caller uploads gzip. So the untar step now picks whichever file is present:

- `public.tar.zst` → zstd path
- `public.tar.gz` → gzip path (unchanged behaviour for the other 15 repos)
- neither → fails loudly with an `::error::` annotation and a directory listing

All three branches tested locally. Only web-astro produces zstd; nothing else changes.

## `set -euo pipefail` is load-bearing

GitHub's default shell is `bash -e`, which does **not** enable `pipefail`. In `tar -cf - dir | zstd ...` a failing `tar` would be masked by `zstd` exiting 0. Verified rather than assumed:

```
without pipefail: exit=0, produced a 45-byte "archive"   ← silent truncation
with    pipefail: exit=1
```

Without it a broken build uploads a truncated artifact that only surfaces as a broken deploy. This is the riskiest aspect of using a pipeline and the reason the step is a block.

Belt and braces: the producer also runs `zstd -t` on the result (**0.26s** on a 33 MB archive) so a corrupt write fails the build rather than the deploy.

## Verification done locally

- Producer → consumer round trip with the **exact commands from both workflows**: 33 MB archive, extracted **15,138 files / 745 MB matching the source exactly**.
- `zstd -t` passes on the archive.
- All three `docker.yaml` branches exercised.
- Both YAML files parse; `bash -n` clean on both run blocks.

**On local timings not matching CI:** locally the compress is 30.2s for zstd vs 40.1s for gzip — same ordering and same 5× size win, but nothing like the 13× ratio. The reason is that on macOS/APFS `tar` reading 15k small files dominates *both*, whereas on CI the files are page-cached straight after the build so the compressor dominates. CI is the environment that matters and its numbers were measured properly; I'm flagging the discrepancy rather than quietly reporting only the flattering figure.

## Fallbacks

Both steps fall back to gzip with a `::warning::` annotation if zstd is ever absent from a runner image (it is preinstalled on `ubuntu-24.04` and `ubuntu-24.04-arm`, confirmed by running it on both). The upload lists both filenames with `if-no-files-found: error`, so a missing artifact fails loudly instead of producing an empty image.

## Still outstanding

**No end-to-end CI run yet** — a real build producing a zstd artifact that the docker job then untars. I'd like to pin `freeletics-web-astro`'s `docker.yaml` at this branch in a throwaway PR to exercise the full path before merging, and report the timings back here. Everything above is local plus the isolated compression benchmark.

## History

The first commit on this branch used `pigz` (the conservative, gzip-compatible option). That was my own choice of the low-risk path, not the requested one — superseded by the zstd commit. Squash on merge.
