### PR TITLE
feat(web-astro): add runs_on input so consumers can pick the runner (PE-48094)

### DIFF
--- a/.github/workflows/web-astro.yaml
+++ b/.github/workflows/web-astro.yaml
@@ -77,6 +77,11 @@ on:
         description: "Name of the npm script that fetches CMS data (delta mode). Skipped when CMS_DATA_DIR is empty."
         type: string
         default: "cms:dump"
+      runs_on:
+        required: false
+        description: "Runner label for the build job. `ubuntu-24.04-arm` measured ~10% faster than x64 for the Astro build (PE-48094, n=5). Opt-in per repo; the default keeps current behaviour."
+        type: string
+        default: "ubuntu-latest"
 
 permissions:
   id-token: write
@@ -89,7 +94,7 @@ jobs:
     env:
       APP_ENV: "${{ contains(github.ref, 'refs/tags/') && 'production' || inputs.APP_ENV }}"
     name: Build app
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on }}
     steps:
       ################################# PRE STEPS ###############################################
       - name: Skip Duplicate Actions


### PR DESCRIPTION
Adds a \`runs_on\` input to \`web-astro.yaml\`, defaulting to \`ubuntu-latest\`. **No behaviour change** unless a consumer opts in.

## Why

\`ubuntu-24.04-arm\` measured **~10% faster** for the Astro build — PE-48094, n=5 per arch on run [31264068849](https://github.com/freeletics/freeletics-web-astro/actions/runs/31264068849):

| | x64 | ARM |
| --- | --- | --- |
| median build | 79.8s | **71.8s** |
| range | 65.2–87.1 (1.34x) | 66.1–83.4 (1.26x) |
| pages built | 15,183 | 15,183 |

## How much to trust that

Less than the headline suggests. The ranges overlap, and the **fastest single run of all ten was x64** (65.2s on an Intel Xeon 6973P-C). The ~8s median gain is roughly one standard deviation at n=5. Sell it as "probably ~10%, high variance either way".

The bigger effect is the one this PR does not fix: x64 build times ranged **65.2s to 87.1s purely on which CPU the job drew** — a 34% swing, larger than the entire ARM difference. Same fleet heterogeneity PE-47984 documented for Rails.

## Scope

Only `Build app` is parameterised. The Docker job stays x64 deliberately — the build output is architecture-neutral HTML/CSS/JS, so there is no reason to move image building and every reason not to.

Correctness is not in question: all 10 runs produced identical page counts (15,183), and an earlier end-to-end run built and pushed an image from an ARM-produced artifact.

## Follow-up

`freeletics-web-astro` opts in via `runs_on: ubuntu-24.04-arm` once this merges.