### PR TITLE
Announce custom-branch Integration deploys in Slack

### DIFF
--- a/.github/actions/slack-deploy-notify/action.yml
+++ b/.github/actions/slack-deploy-notify/action.yml
@@ -1,0 +1,225 @@
+name: "Slack deploy notification"
+description: >-
+  Announce in Slack who is deploying which branch of which service, routing the
+  message to the backend or the web channel.
+
+# Integration is a shared environment: one person's custom branch sitting on it
+# silently breaks everyone else's testing. This posts "who / which branch /
+# which service / what changed" so the channel can see it happen.
+#
+# Service names and Slack handles are NOT duplicated here. Both are read at run
+# time from freeletics/fl-bolt, which is already the single source of truth for
+# the Slack bot:
+#
+#   src/config/constants.js        ghaMapping: SERVICE key -> GitHub repo name
+#   src/localDB/github-to-slack.yml  GitHub login -> Slack member ID
+#
+# Add a new service or a new colleague there and this action picks it up on the
+# next deploy -- nothing in this repo needs to change.
+#
+# Every failure mode here degrades instead of blocking: an unreachable fl-bolt,
+# an unmapped repo or an unknown GitHub login all still produce a message, just
+# a less decorated one. Callers should additionally set `continue-on-error: true`
+# so a Slack outage can never fail a deploy.
+
+inputs:
+  github_token:
+    description: >-
+      Token with read access to freeletics/fl-bolt (JENKINS_PAT_FLUXCD). Without
+      it the mappings are skipped and the raw repo name / GitHub handle are used.
+    required: false
+    default: ""
+  slack_webhook_backend:
+    description: Incoming webhook for the backend channel (SLACK_CIR_BACKEND_HOOK).
+    required: false
+    default: ""
+  slack_webhook_web:
+    description: Incoming webhook for the web channel (SLACK_CIR_WEB_HOOK).
+    required: false
+    default: ""
+  environment:
+    description: Environment being deployed to, as it should read in the message.
+    required: false
+    default: "Integration"
+  target:
+    description: >-
+      Which channel to post in. `auto` derives it from the fl-bolt mapping (keys
+      starting with WEB go to the web channel, everything else to backend);
+      `backend` / `web` force it; `none` disables the notification.
+    required: false
+    default: "auto"
+  branch:
+    description: Branch being deployed. Defaults to the ref the workflow runs on.
+    required: false
+    default: ""
+  actor:
+    description: GitHub login of the deployer. Defaults to the run's actor.
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build deploy message
+      id: message
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        TARGET: ${{ inputs.target }}
+        ENVIRONMENT: ${{ inputs.environment }}
+        REPO: ${{ github.event.repository.name }}
+        OWNER: ${{ github.repository_owner }}
+        SERVER_URL: ${{ github.server_url }}
+        ACTOR: ${{ inputs.actor != '' && inputs.actor || github.actor }}
+        BRANCH: ${{ inputs.branch != '' && inputs.branch || github.ref_name }}
+        # Web repos are on `main`, the Rails services on `master`; never assume.
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      run: |
+        set -uo pipefail
+
+        default_branch="${DEFAULT_BRANCH:-master}"
+
+        # Text that ends up between Slack's own markup needs these three
+        # escaped; URLs get percent-encoding instead.
+        # https://docs.slack.dev/messaging/formatting-message-text
+        slack_escape() {
+          printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+        }
+
+        # An unescaped '&' in the href would cut the link short in Slack. Encode
+        # per path segment so that a branch like `fix/PE-1&2` survives while the
+        # slashes GitHub's compare URL needs stay literal.
+        url_encode_ref() {
+          jq -rR 'split("/") | map(@uri) | join("/")' <<<"$1"
+        }
+
+        # Raw file out of the (private) fl-bolt repo. Never fatal: a missing or
+        # expired PAT costs us the decoration, not the message.
+        fl_bolt_file() {
+          [ -n "$GH_TOKEN" ] || return 1
+          curl -fsSL --max-time 20 \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github.raw" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/freeletics/fl-bolt/contents/$1?ref=main"
+        }
+
+        ##### Which service is this? ghaMapping maps SERVICE -> repo name, so we
+        ##### look the repo up on the value side to get the name humans use.
+        service=""
+        if constants=$(fl_bolt_file "src/config/constants.js"); then
+          service=$(printf '%s\n' "$constants" \
+            | sed -n '/const ghaMapping[[:space:]]*=[[:space:]]*{/,/^};/p' \
+            | sed 's:[[:space:]]//.*::' \
+            | awk -F: -v repo="$REPO" '
+                NF < 2 { next }
+                { gsub(/[ \t]/, "", $1); gsub(/[ \t",]/, "", $2) }
+                $2 == repo { print $1; exit }')
+        else
+          echo "::warning::could not read fl-bolt constants.js -- falling back to the repo name"
+        fi
+
+        if [ -z "$service" ]; then
+          echo "::warning::'$REPO' is not in ghaMapping (freeletics/fl-bolt src/config/constants.js) -- add it there to get the service name and channel routing right"
+          service="$REPO"
+        fi
+
+        ##### Which channel? The WEB* keys are the web services; anything we
+        ##### could not resolve falls back to a guess on the repo name.
+        channel="$TARGET"
+        if [ "$channel" = "auto" ]; then
+          case "$service" in
+            WEB*)   channel="web" ;;
+            "$REPO")  # unresolved -- guess rather than post to the wrong channel silently
+              case "$REPO" in
+                *web*) channel="web" ;;
+                *)     channel="backend" ;;
+              esac
+              echo "::warning::guessed the '$channel' channel from the repo name; set the action's target input to be explicit"
+              ;;
+            *)      channel="backend" ;;
+          esac
+        fi
+
+        ##### Who deployed? Unlisted logins stay plaintext, as documented in
+        ##### fl-bolt's github-to-slack.yml.
+        slack_id=""
+        if mapping=$(fl_bolt_file "src/localDB/github-to-slack.yml"); then
+          slack_id=$(printf '%s\n' "$mapping" \
+            | sed 's/#.*$//' \
+            | awk -F: -v user="$ACTOR" '
+                NF < 2 { next }
+                { gsub(/[ \t]/, "", $1); gsub(/[ \t]/, "", $2) }
+                $1 != "" && tolower($1) == tolower(user) { print $2; exit }')
+        fi
+
+        if [ -n "$slack_id" ]; then
+          who="<@${slack_id}>"
+        else
+          who="$(slack_escape "$ACTOR")"
+          echo "::notice::'$ACTOR' has no Slack member ID in freeletics/fl-bolt src/localDB/github-to-slack.yml -- add it to be @-mentioned"
+        fi
+
+        branch_txt=$(slack_escape "$BRANCH")
+        service_txt=$(slack_escape "$service")
+        env_txt=$(slack_escape "$ENVIRONMENT")
+
+        if [ "$BRANCH" = "$default_branch" ]; then
+          # Not a custom branch: someone is handing the environment back.
+          text=":information_source: ${who} Deploying \`${branch_txt}\` to ${env_txt} for *${service_txt}* -- back on the default branch"
+        else
+          compare="${SERVER_URL}/${OWNER}/${REPO}/compare/$(url_encode_ref "$default_branch")...$(url_encode_ref "$BRANCH")"
+          diff_txt=$(slack_escape "${default_branch}...${BRANCH}")
+          text=":information_source: ${who} Deploying custom branch \`${branch_txt}\` to ${env_txt} for *${service_txt}*, diff: <${compare}|${diff_txt}>"
+        fi
+
+        {
+          echo "channel=$channel"
+          echo "text<<SLACK_MESSAGE_EOF"
+          echo "$text"
+          echo "SLACK_MESSAGE_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "Channel: $channel"
+        echo "Message: $text"
+
+    - name: Post to Slack
+      shell: bash
+      env:
+        CHANNEL: ${{ steps.message.outputs.channel }}
+        TEXT: ${{ steps.message.outputs.text }}
+        # Both are passed in and picked here so no webhook URL ever travels
+        # through a step output.
+        WEBHOOK_BACKEND: ${{ inputs.slack_webhook_backend }}
+        WEBHOOK_WEB: ${{ inputs.slack_webhook_web }}
+      run: |
+        set -uo pipefail
+
+        case "$CHANNEL" in
+          web)     webhook="$WEBHOOK_WEB"; secret_name="SLACK_CIR_WEB_HOOK" ;;
+          backend) webhook="$WEBHOOK_BACKEND"; secret_name="SLACK_CIR_BACKEND_HOOK" ;;
+          none)    echo "Notification disabled (target: none)"; exit 0 ;;
+          *)       echo "::error::unknown target '$CHANNEL' -- expected auto, backend, web or none"; exit 1 ;;
+        esac
+
+        if [ -z "$webhook" ]; then
+          echo "::warning::$secret_name is not set for this repository -- skipping the Slack notification"
+          exit 0
+        fi
+
+        # jq does the JSON escaping; unfurling off so the compare link stays a
+        # link instead of a full-width GitHub preview.
+        payload=$(jq -nc --arg text "$TEXT" '{text: $text, unfurl_links: false, unfurl_media: false}')
+
+        response=$(curl -sS --max-time 20 --retry 2 --retry-delay 3 \
+          -X POST -H 'Content-Type: application/json' \
+          --data "$payload" "$webhook") || {
+            echo "::warning::could not reach Slack -- deploy is unaffected"
+            exit 0
+          }
+
+        if [ "$response" != "ok" ]; then
+          echo "::warning::Slack rejected the message: $response"
+          exit 0
+        fi
+        echo "Posted to the $CHANNEL channel"

--- a/.github/workflows/gha-deploy-integration.yaml
+++ b/.github/workflows/gha-deploy-integration.yaml
@@ -31,6 +31,32 @@ on:
         required: false
         type: boolean
         default: true
+      SLACK_NOTIFY:
+        description: >-
+          Announce the deploy in Slack. Integration is shared, so this is on by
+          default: turn it off only for services nobody else tests against.
+        required: false
+        type: boolean
+        default: true
+      SLACK_TARGET:
+        description: >-
+          Which channel to announce in. `auto` derives it from fl-bolt's
+          ghaMapping (WEB* services go to the web channel, everything else to
+          backend); `backend` / `web` force it, `none` is the same as
+          SLACK_NOTIFY: false.
+        required: false
+        type: string
+        default: "auto"
+    secrets:
+      # All callers use `secrets: inherit`, so these are declared purely to
+      # document what this workflow reaches for. Each one degrades to a warning
+      # when unset -- the deploy itself never depends on them.
+      SLACK_CIR_BACKEND_HOOK:
+        required: false
+      SLACK_CIR_WEB_HOOK:
+        required: false
+      JENKINS_PAT_FLUXCD:
+        required: false
 
 permissions:
   id-token: write
@@ -154,6 +180,28 @@ jobs:
             inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION
             }}.amazonaws.com/kaniko-cache:${{ github.event.repository.name }}
 
+
+      # Integration is shared: a custom branch parked on it quietly invalidates
+      # whatever everyone else is testing. Announce who took it, for which
+      # service, and what is in the branch.
+      #
+      # Deliberately after the push rather than before the build: an image that
+      # never built is not a deploy, and a false alarm in this channel trains
+      # people to ignore it. Deliberately continue-on-error: a Slack outage must
+      # never be the reason a deploy is marked failed.
+      #
+      # Service names and Slack handles come from freeletics/fl-bolt at run time
+      # -- see the action for why, and add new services/people there, not here.
+      - name: Announce deploy in Slack
+        if: ${{ inputs.SLACK_NOTIFY }}
+        continue-on-error: true
+        uses: freeletics/actions/.github/actions/slack-deploy-notify@main
+        with:
+          github_token: ${{ secrets.JENKINS_PAT_FLUXCD }}
+          slack_webhook_backend: ${{ secrets.SLACK_CIR_BACKEND_HOOK }}
+          slack_webhook_web: ${{ secrets.SLACK_CIR_WEB_HOOK }}
+          environment: Integration
+          target: ${{ inputs.SLACK_TARGET }}
 
       # we will not activate GH deployment creation for a custom branch deployment for now
       - uses: chrnorm/deployment-action@v2


### PR DESCRIPTION
Integration is shared: a custom branch parked on it quietly invalidates whatever everyone else is testing, and today nothing says who took it.

Adds a `slack-deploy-notify` composite action and calls it from `gha-deploy-integration.yaml` — the explicit **Deploy integration** dispatch only. The auto-deploy-on-merge path (`gha-auto-deploy-integration.yaml`) is untouched.

```
:information_source: @Alberto Fulcini Deploying custom branch `PE-47968-timeouts` to Integration
for *AUDIT*, diff: master...PE-47968-timeouts
```

Deploying the default branch instead reads `Deploying \`master\` … — back on the default branch` with no diff link, so the channel also sees Integration handed back.

## Nothing is duplicated in this repo

Service names and Slack handles are read at run time from `freeletics/fl-bolt`, already the source of truth for the Slack bot:

| | |
|---|---|
| `src/config/constants.js` | `ghaMapping` — reverse lookup, repo name → `AUDIT`, `WEB`, `WEB_ASTRO`… |
| `src/localDB/github-to-slack.yml` | GitHub login → Slack member ID, for the @-mention |

Add a service or a colleague **there** and the next deploy picks it up; nothing here changes. The same mapping picks the channel — `WEB*` services go to `SLACK_CIR_WEB_HOOK`, everything else to `SLACK_CIR_BACKEND_HOOK`.

## Failure modes

Every one of them degrades instead of blocking, and the step is `continue-on-error`, so a Slack outage or an expired PAT can never fail a deploy:

- fl-bolt unreachable / no PAT → repo name and plaintext handle, `::warning::`
- repo not in `ghaMapping` → repo name, channel guessed from the repo name, `::warning::` naming the file to fix
- deployer not in `github-to-slack.yml` → plaintext handle, `::notice::` (this is the documented fallback in that file)
- webhook secret unset → skipped with a `::warning::`

Posted **after** the image push rather than before the build: an image that never built is not a deploy, and false alarms train people to ignore the channel.

## Before this is live

1. `SLACK_CIR_BACKEND_HOOK` and `SLACK_CIR_WEB_HOOK` must exist as org secrets visible to the service repos.
2. `JENKINS_PAT_FLUXCD` needs **read access to `freeletics/fl-bolt`**. It is used today for `freeletics/releases`; if it is fine-grained and scoped per repo, fl-bolt has to be added.

Service repos need no changes — they already pass `secrets: inherit`.

## Testing

- `actionlint` with the repo's CI config, and `yamllint`: clean
- both `run:` blocks: shellcheck-clean
- dry-ran the message-building script against the real fl-bolt files with mocked network: all 14 `ghaMapping` services resolve to the right key and channel, case-insensitive login lookup, plus the unmapped-repo, missing-PAT, unknown-deployer, empty-`default_branch`, forced-`target` and `&`-in-branch-name cases

Two escape hatches on the caller if a service ever needs them: `SLACK_NOTIFY: false` and `SLACK_TARGET: backend|web|none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
